### PR TITLE
Add check for config option "Allow Sprinting"

### DIFF
--- a/src/main/java/ts2k16/handlers/PlayerGrowthManager.java
+++ b/src/main/java/ts2k16/handlers/PlayerGrowthManager.java
@@ -32,13 +32,16 @@ public class PlayerGrowthManager
 		
 		if(player.isSprinting())
 		{
-			if(!wasSprinting)
+			if(TSSettings.allowSprint)
 			{
-				sprintTime = player.ticksExisted;
-			} else if(player.ticksExisted - sprintTime > TSSettings.cooldown)
-			{
-				pulseGrowth(player.worldObj, player.getPosition(), player);
-				sprintTime = player.ticksExisted;
+				if(!wasSprinting)
+				{
+					sprintTime = player.ticksExisted;
+				} else if(player.ticksExisted - sprintTime > TSSettings.cooldown)
+				{
+					pulseGrowth(player.worldObj, player.getPosition(), player);
+					sprintTime = player.ticksExisted;
+				}
 			}
 		} else if(player.isSneaking() && !wasCrouched)
 		{


### PR DESCRIPTION
There was no check being made to see if the configuration option for allowing sprinting to cause a pulseGrowth, and as such was acting as if the option was always set true.